### PR TITLE
Use megabytes for file sizes in INSTALL.TXT

### DIFF
--- a/INSTALL.TXT
+++ b/INSTALL.TXT
@@ -16,10 +16,10 @@ Prerequisites:
      peering LAN for some of the layer 3 reporting to work.
   - Disk space for sample files. I allow at least 10Gig, but this is because
     I want to store a few months of samples.
-      The sample files here take up about 8Mb per day based on 15 Minute
+      The sample files here take up about 8 MB per day based on 15 minute
       sampling (running IXP Watch every 15 minutes for 15 minutes)
       However, during storms or other flooded traffic, these files grow.
-      The largest individual sample file I've got is 430Mb.
+      The largest individual sample file I've got is 430 MB.
      (ixp-watch has some facility to manage large files to avoid disks filling up.)
   - syslogd or logging facility if you want to syslog the traffic alarms etc.
   - and, of course, the bash shell.


### PR DESCRIPTION
Current "Mb" seems like it means megabits but surely the file sizes are in bytes. So change Mb to MB and also add a space between value and unit.
One word also capitalized wrong.